### PR TITLE
docs: Updated external FHIR links to permanent R4 urls

### DIFF
--- a/input/fsh/extensions/gender-original-text.fsh
+++ b/input/fsh/extensions/gender-original-text.fsh
@@ -1,6 +1,6 @@
 Extension: GenderOriginalText
 Id: gender-original-text
-Description: "Text provided by the person with the choice of 'Another gender' (The FHIR AdministrativeGender CodeSystem codes this as '[other](http://hl7.org/fhir/R4B/codesystem-administrative-gender.html)')."
+Description: "Text provided by the person with the choice of 'Another gender' (The FHIR AdministrativeGender CodeSystem codes this as '[other](https://hl7.org/fhir/R4/codesystem-administrative-gender.html)')."
 
 * ^url = "http://hl7.org.nz/fhir/StructureDefinition/gender-original-text"
 //* ^jurisdiction.coding = urn:iso:std:iso:3166#NZ

--- a/input/pagecontent/StructureDefinition-edi-address-intro.md
+++ b/input/pagecontent/StructureDefinition-edi-address-intro.md
@@ -5,7 +5,7 @@
 
 This extension allows an EDI address to be added to the ContactPoint.system element.
 
-As the FHIR specification has a [required](http://hl7.org/fhir/terminologies.html#required) binding for this element, it is necessary to
+As the FHIR specification has a [required](https://hl7.org/fhir/R4/terminologies.html#required) binding for this element, it is necessary to
 provide a value from the defined set (eg 'other') then place the extension on that value.
 
 The actual value of the edi address is the .value element.

--- a/input/pagecontent/extensions.xml
+++ b/input/pagecontent/extensions.xml
@@ -145,7 +145,7 @@
 <td>
 <div>Patient.gender</div>
 </td>
-<td><p>Text provided by the person with the choice of &#39;Another gender&#39; (The FHIR AdministrativeGender CodeSystem codes this as &#39;<a href="http://hl7.org/fhir/R4B/codesystem-administrative-gender.html">other</a>&#39;).</p></td>
+<td><p>Text provided by the person with the choice of &#39;Another gender&#39; (The FHIR AdministrativeGender CodeSystem codes this as &#39;<a href="https://hl7.org/fhir/R4/codesystem-administrative-gender.html">other</a>&#39;).</p></td>
 <td></td>
 </tr>
 <tr>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -24,7 +24,7 @@ The following tabs are available from the navbar at the top.
 
 ### Extensions
 
-This tab lists all the extensions defined in this guide, where an extension is an additional element that can be recorded in a resource. The extension definition describes the purpose of the extension, its name and [dataType/s](http://hl7.org/fhir/datatypes.html).
+This tab lists all the extensions defined in this guide, where an extension is an additional element that can be recorded in a resource. The extension definition describes the purpose of the extension, its name and [dataType/s](https://hl7.org/fhir/R4/datatypes.html).
 
 Clicking on the link in the 'id' column will display the detail page for that extension. Extensions can have a single value, or can be composed of multiple 'child' elements - an example is the [funded programme](StructureDefinition-funded-programme.html) extension. The snapshot tab in the details page (about halfway down) lists all the parts of the extension - including a link to the ValueSet if the element is coded.
 
@@ -32,12 +32,12 @@ Clicking on the link in the 'id' column will display the detail page for that ex
 
 This tab lists the terminology artifacts defined in this guide. There are 2 artifacts that will be found here:
 
-* [ValueSets](http://hl7.org/fhir/valueset.html) are sets of codes, drawn from one or more code systems, intended for use in coded data elements in Resources, as defined by a particular conformance rule - such as an Extension or Profile. The ValueSets in this Guide are 'recommended' values, but it may be possible for implementers to use additional concepts if the rules defined by a particular Extension or Profile permit this.
-* [CodeSystem](http://hl7.org/fhir/codesystem.html) resources are used to declare the existence of and describe a code system, its key properties, and optionally define a part or all of its content. Wherever possible, the use of international terminologies, such as [SNOMED CT](https://www.snomed.org/), is recommended; however, a number of New Zealand-specific code systems are included in this Guide to meet unique, local requirements.
+* [ValueSets](https://hl7.org/fhir/R4/valueset.html) are sets of codes, drawn from one or more code systems, intended for use in coded data elements in Resources, as defined by a particular conformance rule - such as an Extension or Profile. The ValueSets in this Guide are 'recommended' values, but it may be possible for implementers to use additional concepts if the rules defined by a particular Extension or Profile permit this.
+* [CodeSystem](https://hl7.org/fhir/R4/codesystem.html) resources are used to declare the existence of and describe a code system, its key properties, and optionally define a part or all of its content. Wherever possible, the use of international terminologies, such as [SNOMED CT](https://www.snomed.org/), is recommended; however, a number of New Zealand-specific code systems are included in this Guide to meet unique, local requirements.
 
-These resources can be used by Terminology Servers (like [Terminz](https://terminz-itp.azurewebsites.net/) or [Ontoserver](https://aehrc.com/ontoserver/) ) to provide terminology [operations](http://hl7.org/fhir/operations.html) of use to implementers, such as the ValueSet [$expand](http://hl7.org/fhir/valueset-operation-expand.html) operation.
+These resources can be used by Terminology Servers (like [Terminz](https://terminz-itp.azurewebsites.net/) or [Ontoserver](https://aehrc.com/ontoserver/) ) to provide terminology [operations](https://hl7.org/fhir/R4/operations.html) of use to implementers, such as the ValueSet [$expand](https://hl7.org/fhir/R4/valueset-operation-expand.html) operation.
 
-There is a lot more detail on terminology in the [FHIR specification](http://hl7.org/fhir/terminology-module.html). The section on [Terminology Services](http://hl7.org/fhir/terminology-service.html) is also useful.
+There is a lot more detail on terminology in the [FHIR specification](https://hl7.org/fhir/R4/terminology-module.html). The section on [Terminology Services](https://hl7.org/fhir/R4/terminology-service.html) is also useful.
 
 ### Identifiers
 

--- a/input/pagecontent/namingSystems.md
+++ b/input/pagecontent/namingSystems.md
@@ -2,7 +2,7 @@
 ### Identifiers
 
 <div>
-These are identifiers defined in this IG. They are defined using <a href='http://hl7.org/fhir/namingsystem.html'>NamingSystem</a> resources.
+These are identifiers defined in this IG. They are defined using <a href='https://hl7.org/fhir/R4/namingsystem.html'>NamingSystem</a> resources.
 </div>
 
 <table class='table table-bordered table-condensed'>

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -2,11 +2,11 @@
 
 These are ValueSets that have been defined in this guide for coded elements. 
 
-Each ValueSet resource has a globally unique url (the [Canonical](http://hl7.org/fhir/references.html#canonical) url) that is used to unambiguously identify it. 
+Each ValueSet resource has a globally unique url (the [Canonical](https://hl7.org/fhir/R4/references.html#canonical) url) that is used to unambiguously identify it. 
 This url generally should resolve to the to the FHIR ValueSet resource, though the infrastructure 
-to support this is not yet in place. There's a [specific note](http://hl7.org/fhir/valueset.html#ident) in the spec on ValueSet identification.
+to support this is not yet in place. There's a [specific note](https://hl7.org/fhir/R4/valueset.html#ident) in the spec on ValueSet identification.
 
-The [FHIR spec](http://hl7.org/fhir/terminology-module.html) has much more detail on the use of Terminology in FHIR.
+The [FHIR spec](https://hl7.org/fhir/R4/terminology-module.html) has much more detail on the use of Terminology in FHIR.
 
 
 <table class='table table-bordered table-condensed'>
@@ -42,7 +42,7 @@ These are code systems that have been defined in this guide. They define specifi
 
 Each CodeSystem resource has a globally unique url (the canonical url) that is used to unambiguously identify it. The url generally refers to a description of the codesystem, rather than to the FHIR CodeSystem resource.
 
-The [FHIR spec](http://hl7.org/fhir/terminology-module.html) has much more detail on the use of Terminology in FHIR
+The [FHIR spec](https://hl7.org/fhir/R4/terminology-module.html) has much more detail on the use of Terminology in FHIR
 
 <table class='table table-bordered table-condensed'>
 <tr><th>CodeSystem</th><th>Purpose</th><th>Canonical Url</th></tr>

--- a/makeTerminologySummary.js
+++ b/makeTerminologySummary.js
@@ -39,11 +39,11 @@ arVS.push("<tr><th>ValueSet</th><th>Purpose</th><th>Url</th><th>CodeSystem Urls<
 arCS.push("### CodeSystems");
 //arCS.push("\r\n");
 let csText = `
-These are codesystems that have been defined by this guide. They define specific concepts that are included in ValueSets. It is preferabe to use an international code systm such as SNOMED, ICD or LOINC - but this is not always possible.
+These are codesystems that have been defined by this guide. They define specific concepts that are included in ValueSets. It is preferable to use an international code system such as SNOMED, ICD or LOINC - but this is not always possible.
 
-Each CodeSystem has a globally unique url that is used to unambiguously identiy it. The url generally refers to a describtion of the codesystem, rather than to the FHIR CodeSystem resource.
+Each CodeSystem has a globally unique url that is used to unambiguously identify it. The url generally refers to a description of the codesystem, rather than to the FHIR CodeSystem resource.
 
-The [FHIR spec](http://hl7.org/fhir/terminology-module.html) has much more detail on the use of Terminology in FHIR
+The [FHIR spec](https://hl7.org/fhir/R4/terminology-module.html) has much more detail on the use of Terminology in FHIR
 `
 arCS.push(csText);
 //arCS.push("\r\n");
@@ -154,4 +154,3 @@ function loadFile(path) {
     let resource = JSON.parse(contents)
     return resource;
 }
-


### PR DESCRIPTION
This pull request is to address the current working group item to replace the links to the FHIR Specification in the IG homepage to the permanent R4 links, as opposed to the current links, which link to the latest FHIR version.

I have noted a couple of other areas where this problem also exists, so I have addressed these in a separate commit. If we want to keep it to just the homepage, I can revert the commit with the additional changes.

