### PR TITLE
add sdhr-id namingsystem

### DIFF
--- a/input/fsh/vocabulary/namingSystems.fsh
+++ b/input/fsh/vocabulary/namingSystems.fsh
@@ -599,7 +599,7 @@ Instance: sdhr-id
 InstanceOf: NamingSystem
 Usage: #definition
 * name = "SDHR Id NamingSystem"
-* description = "The SDHR (Shared Digital Health Record) id NamingSystem identifies the SDHR resource id namespace."
+* description = "Identifier namespace for SDHR-assigned resource identifiers. This sdhr-id identifier is recorded in Resource.identifier on a local resource to support synchronisation with the SDHR Data Service. Its value is the original SDHR-assigned FHIR Resource.id, allowing the integrating system to preserve a reference to the SDHR resource. This enables the system to match the local resource back to the corresponding SDHR resource during future synchronisation and other interactions."
 * status = #active
 * kind = #identifier
 * date = "2026-06-03"
@@ -608,7 +608,6 @@ Usage: #definition
 * contact.telecom.system = #url
 * publisher = "HL7 New Zealand"
 * responsible = "New Zealand Health Information Standards Organisation (HISO)"
-* usage = "The SDHR (Shared Digital Health Record) id NamingSystem identifies the SDHR resource id namespace."
 * jurisdiction = urn:iso:std:iso:3166#NZ
 * uniqueId[+].type = #uri
 * uniqueId[=].value = "https://standards.digital.health.nz/ns/sdhr-id"

--- a/input/fsh/vocabulary/namingSystems.fsh
+++ b/input/fsh/vocabulary/namingSystems.fsh
@@ -595,6 +595,24 @@ Usage: #definition
 * responsible = "New Zealand Health Information Standards Organisation (HISO)"
 * name = "Rheumatic_fever_ccs_id"
 
+Instance: sdhr-id
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "SDHR Id NamingSystem"
+* description = "The SDHR (Shared Digital Health Record) id NamingSystem identifies the SDHR resource id namespace."
+* status = #active
+* kind = #identifier
+* date = "2026-06-03"
+* contact.name = "HL7 New Zealand"
+* contact.telecom.value = "http://hl7.org.nz"
+* contact.telecom.system = #url
+* publisher = "HL7 New Zealand"
+* responsible = "New Zealand Health Information Standards Organisation (HISO)"
+* usage = "The SDHR (Shared Digital Health Record) id NamingSystem identifies the SDHR resource id namespace."
+* jurisdiction = urn:iso:std:iso:3166#NZ
+* uniqueId[+].type = #uri
+* uniqueId[=].value = "https://standards.digital.health.nz/ns/sdhr-id"
+* uniqueId[=].preferred = true
 
 /*
 Instance: nzFacilitylegacy


### PR DESCRIPTION
There is a requirement for a NamingSystem resource to document the Identifier namespace for SDHR-assigned resource identifiers, `https://standards.digital.health.nz`. This `sdhr-id` identifier is recorded in Resource.identifier on a local resource to support synchronisation with SDHR. Its value is the original SDHR-assigned FHIR Resource.id, allowing the integrating system to preserve a reference to the SDHR resource. This enables the system to match the local resource back to the corresponding SDHR resource during future synchronisation and other interactions.

```mermaid
sequenceDiagram
    participant Client as Sector system
    participant SDHR as SDHR FHIR server
    participant Store as Other system

    Client->>SDHR: Create resource
    SDHR-->>Client: Created resource with `id`
    Client->>Store: Persist SDHR `id` as secondary identifier
    Store->>Store: Store `Identifier.system = https://standards.digital.health.nz/ns/sdhr-id`
    Store->>Store: Store `Identifier.value = <SDHR resource id>`
```

Pull request: https://github.com/HL7NZ/nzbase/pull/130